### PR TITLE
Update view counter because it's being overloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 
 <p align="center">
-    <a href="https://github.com/serfend/pydumpck/"><img alt="pypi version" src="https://visitor-badge.glitch.me/badge?page_id=serfend/pydumpck&left_text=views" /></a> 
+    <a href="https://visitorbadge.io/status?path=https%3A%2F%2Fgithub.com%2Fserfend%2Fpydumpck%2F"><img src="https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2Fserfend%2Fpydumpck%2F&labelColor=%23697689&countColor=%23ff8a65&style=plastic&labelStyle=none" /></a>
     <a href="https://pypi.python.org/pypi/pydumpck/"><img alt="pypi version" src="https://img.shields.io/pypi/v/pydumpck.svg" /></a> 
     <a href="https://pypistats.org/packages/pydumpck"><img alt="pypi download" src="https://img.shields.io/pypi/dm/pydumpck.svg" /></a>
     <a href="https://github.com/serfend/pydumpck/releases"><img alt="GitHub release" src="https://img.shields.io/github/release/serfend/pydumpck.svg?style=flat-square" /></a>


### PR DESCRIPTION
💀 same issue happens with the original repo's readme since it's being overloaded. Easiest fix is to just use a different view counter. If you don't like the colors or something u can check the [site](https://www.visitorbadge.io/)